### PR TITLE
Color regex fix

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -59,7 +59,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "#([0-9][a-f]){3,6}"
+            "pattern": "#([0-9a-f]){3,6}"
           }
         }
       }


### PR DESCRIPTION
It was not valid for #d5d5d5. This now works for this array.
```
[
    "#d5d5d5",
    "#616e79",
    "#ffffff",
]
```
New:
![image](https://user-images.githubusercontent.com/7527244/232955448-cf2497cf-7bb7-4091-a24c-d37dc943d01f.png)

Old:
![image](https://user-images.githubusercontent.com/7527244/232955507-6ee3cb3d-09b2-4c15-a81b-836cbee59fef.png)

