### PR TITLE
Add description with max length

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -32,6 +32,10 @@
         "species": {
           "type": "string"
         },
+        "description": {
+          "type": "string",
+          "maxLength": 250
+        },
         "ref": {
           "type": "string",
           "format": "uri",


### PR DESCRIPTION
I added the max length to be 250. That feels long enough but could be longer or shorter.