### PR TITLE
More consistent hexadecimal color matching

### DIFF
--- a/schema-07.json
+++ b/schema-07.json
@@ -69,7 +69,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "#([0-9a-f]){3,6}"
+            "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
           }
         }
       }

--- a/schema-07.json
+++ b/schema-07.json
@@ -69,7 +69,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+            "pattern": "^#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})$"
           }
         }
       }

--- a/schema.cue
+++ b/schema.cue
@@ -25,5 +25,5 @@ import (
 	age?: int
 	birthdate?: string
 	description: strings.MaxRunes(250)
-	colors?: [...=~"#([0-9a-f]){3,6}"]
+	colors?: [...=~"^#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})$"]
 }

--- a/schema.json
+++ b/schema.json
@@ -66,7 +66,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "#([0-9a-f]){3,6}"
+            "pattern": "^#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})$"
           }
         }
       }


### PR DESCRIPTION
The original regex did not permit uppercase letters in the first three characters of the color string. This new regex permits uppercase letters.

Also the new pattern correctly checks the entire string of matching hex for valid characters, rather than stopping at the first three.